### PR TITLE
Name of installation dir is now explicitly defined in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,5 +5,8 @@
         "composer/installers": ">=1.0.8",
         "hypejunction/hypewall": "dev-master"
     },
-    "license": "GPL-2.0"
+    "license": "GPL-2.0",
+	"extra": {
+		"installer-name": "hypeWall_extended"
+	}
 }


### PR DESCRIPTION
The composer package has been named `hypewall_extended`. The the plugin installation dir however needs to be named `hypeWall_extended` ("Wall" with capital letter) in order for the plugin to work.

By defining the exact name in `composer.json`, the directory gets the correct name automatically.
